### PR TITLE
Fix broken specs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,30 @@
+version: 2
+
+.build_template: &build_definition
+  steps:
+    - checkout
+    - run: bundle install
+    - run: bundle exec rake
+  working_directory: ~/app
+
+jobs:
+  build:
+    <<: *build_definition
+    docker:
+      - image: ruby:2.5
+  build_ruby2_4:
+    <<: *build_definition
+    docker:
+      - image: ruby:2.4
+  build_ruby2_3:
+    <<: *build_definition
+    docker:
+      - image: ruby:2.3
+
+workflows:
+  version: 2
+  build_ruby_versions:
+    jobs:
+      - build
+      - build_ruby2_4
+      - build_ruby2_3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: ruby
-script: "bundle exec rake"
-rvm:
-  - 2.0.0
-  - 2.1.5
-notifications:
-  email: false

--- a/spec/trust_me_spec.rb
+++ b/spec/trust_me_spec.rb
@@ -10,7 +10,7 @@ describe TrustMe do
   end
 
   let :now_rfc1123 do
-    "Thu, 13 Nov 2016 12:20:00 GMT"
+    "Sun, 13 Nov 2016 12:20:00 GMT"
   end
 
   let :uuid do

--- a/trust_me.gemspec
+++ b/trust_me.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.files     += Dir["{lib,spec,vendor}/**/*"]
 
   s.add_development_dependency "rspec",       "3.1"
-  s.add_development_dependency "webmock",     "1.20.4"
+  s.add_development_dependency "webmock",     "1.24.6"
   s.add_development_dependency "rake-tomdoc", "0.0.2"
   s.add_development_dependency "rake"
 end

--- a/trust_me.gemspec
+++ b/trust_me.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec",       "3.1"
   s.add_development_dependency "webmock",     "1.24.6"
   s.add_development_dependency "rake-tomdoc", "0.0.2"
-  s.add_development_dependency "rake"
+  s.add_development_dependency "rake",        "12.3.0"
 end

--- a/trust_me.gemspec
+++ b/trust_me.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.files      = %w[ Rakefile README.markdown ]
   s.files     += Dir["{lib,spec,vendor}/**/*"]
 
-  s.add_development_dependency "rspec",       "3.1"
+  s.add_development_dependency "rspec",       "3.7.0"
   s.add_development_dependency "webmock",     "1.24.6"
   s.add_development_dependency "rake-tomdoc", "0.0.2"
   s.add_development_dependency "rake",        "12.3.0"


### PR DESCRIPTION
CI was never setup after this repo moved from its old home at Site5. 

- The date used in specs incorrectly referred to "Thu, 12 Nov 2016", it is actually a Sunday
- Webmock needed to be updated
- Travis is removed in favor of CircleCi
- Rake and RSpec needed to be updated